### PR TITLE
Fix CI on Ruby 2.5 / 2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,3 +7,4 @@ gem "rake", "~> 13.0"
 gem "activerecord", ">= 5.1"
 gem "sqlite3", ">= 1.3", "< 3", platforms: :mri
 gem "activerecord-jdbcsqlite3-adapter", platforms: :jruby
+gem "rack", "< 3" if RUBY_VERSION < "2.6" # rack 3.x is incompatible with Ruby 2.5 (Enumerable#to_h)

--- a/test/support/active_record.rb
+++ b/test/support/active_record.rb
@@ -1,3 +1,4 @@
+require "logger" if RUBY_VERSION < "2.7" # ActiveSupport 6.1 doesn't require this itself
 require "active_record"
 
 ActiveRecord::Base.establish_connection(


### PR DESCRIPTION
- **Require `logger` explicitly** before `require "active_record"` in the test support.
	ActiveSupport 6.1 doesn't require  `logger` itself, so loading `active_record` raised NameError on Logger.
-  **Pin `rack` to `< 3` on Ruby < 2.6.** rack 3.x raises TypeError on Ruby 2.5 because `Enumerable#to_h` semantics changed in Ruby 2.6.